### PR TITLE
Method to retrieve order history, paginated data & dividends.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,5 @@ Ryan D'souza (@dsouzarc)
 AJ Haggard (@ahaggard2013)
 Jamone Kelly (@jamonek)
 Rohan Pai (@rohanpai)
+Bharath Lohray (@lordloh)
+

--- a/README.md
+++ b/README.md
@@ -45,5 +45,6 @@ See this [blog post](https://medium.com/@rohanpai25/reversing-robinhood-free-acc
   + Last core equity
   + Last core market value
   + Market value
+  + Order history
 * User positions data
   + Securities owned

--- a/README.md
+++ b/README.md
@@ -46,5 +46,6 @@ See this [blog post](https://medium.com/@rohanpai25/reversing-robinhood-free-acc
   + Last core market value
   + Market value
   + Order history
+  + Dividend history
 * User positions data
   + Securities owned

--- a/Robinhood.py
+++ b/Robinhood.py
@@ -192,6 +192,9 @@ class Robinhood:
         
     def order_history(self):
         return self.session.get(self.endpoints['orders']).json()
+        
+    def dividends(self):
+        return self.session.get(self.endpoints['dividends']).json()
 
     ##############################
     # POSITIONS DATA

--- a/Robinhood.py
+++ b/Robinhood.py
@@ -47,7 +47,7 @@ class Robinhood:
 
     def __init__(self):
         self.session = requests.session()
-        self.session.proxies = urllib.getproxies()
+        self.session.proxies = urllib.request.getproxies()
         self.headers = {
             "Accept": "*/*",
             "Accept-Encoding": "gzip, deflate",
@@ -97,7 +97,7 @@ class Robinhood:
         url = str(self.endpoints['quotes']) + str(stock) + "/"
         #Check for validity of symbol
         try:
-            res = json.loads((urllib.urlopen(url)).read());
+            res = json.loads((urllib.request.urlopen(url)).read());
             if len(res) > 0:
                 return res;
             else:

--- a/Robinhood.py
+++ b/Robinhood.py
@@ -151,6 +151,9 @@ class Robinhood:
         res = self.session.get(self.endpoints['accounts'])
         res = res.json()
         return res['results'][0]
+        
+    def get_url(self,url):
+        return self.session.get(url).json()
 
     ##############################
     # PORTFOLIOS DATA
@@ -186,6 +189,9 @@ class Robinhood:
 
     def market_value(self):
         return float(self.portfolios()['market_value'])
+        
+    def order_history(self):
+        return self.session.get(self.endpoints['orders']).json()
 
     ##############################
     # POSITIONS DATA


### PR DESCRIPTION
* Added an `order_history` method to retrieve order history 
* Added a method `get_url` method to get custom URLs that need authentication. This is useful to retrieve paginated data.
* Added a `dividends` method to retrieve data from the dividends endpoint.
* Fix for issue #5. Thanks to the reply from @machbio.

```
from Robinhood import Robinhood
import json

R = Robinhood();
R.login(username="me", password="myPassword")

# Fetch order history
order_history = R.order_history();
print (json.dumps(order_history))

# Get the next page - assuming there is a second page.
print ("Next Page :"+order_history['next']);
page2 = R.get_url(order_history['next'])
print (json.dumps(page2))

# Get the dividends paid so far.
dividend_history = R.dividends()
print(json.dumps(dividend_history))
```