### PR TITLE
Added method to retrieve news & historic Quotes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ See this [blog post](https://medium.com/@rohanpai25/reversing-robinhood-free-acc
   + Adjusted previous close
   + Trading halted
   + Updated at
+  + Historical Price
 * User portfolio data
   + Adjusted equity previous close
   + Equity
@@ -49,3 +50,4 @@ See this [blog post](https://medium.com/@rohanpai25/reversing-robinhood-free-acc
   + Dividend history
 * User positions data
   + Securities owned
+* News

--- a/Robinhood.py
+++ b/Robinhood.py
@@ -111,12 +111,13 @@ class Robinhood:
         data = self.quote_data(stock)
         return data["symbol"]
 
-    def get_historical_quotes(self,symbol,interval,span):
+    def get_historical_quotes(self,symbol,interval,span,bounds='regular'):
         # Valid combination
         # interval = 5minute | 10minute + span = day, week
         # interval = day + span = year
         # interval = week
-        res = self.session.get(self.endpoints['historicals'], params={'symbols':','.join(symbol).upper(), 'interval':interval, 'span':span})
+        # bounds can be 'regular' for regular hours or 'extended' for extended hours
+        res = self.session.get(self.endpoints['historicals'], params={'symbols':','.join(symbol).upper(), 'interval':interval, 'span':span, 'bounds':bounds})
         return res.json()
         
     def get_news(self, symbol):

--- a/Robinhood.py
+++ b/Robinhood.py
@@ -25,9 +25,11 @@ class Robinhood:
             "portfolios":"https://api.robinhood.com/portfolios/",
             "positions":"https://api.robinhood.com/positions/",
             "quotes":"https://api.robinhood.com/quotes/",
+            "historicals":"https://api.robinhood.com/quotes/historicals/",
             "document_requests":"https://api.robinhood.com/upload/document_requests/",
             "user":"https://api.robinhood.com/user/",
-            "watchlists":"https://api.robinhood.com/watchlists/"
+            "watchlists":"https://api.robinhood.com/watchlists/",
+            "news":"https://api.robinhood.com/midlands/news/"
     }
 
     session = None
@@ -108,6 +110,18 @@ class Robinhood:
     def get_quote(self, stock=None):
         data = self.quote_data(stock)
         return data["symbol"]
+
+    def get_historical_quotes(self,symbol,interval,span):
+        # Valid combination
+        # interval = 5minute | 10minute + span = day, week
+        # interval = day + span = year
+        # interval = week
+        res = self.session.get(self.endpoints['historicals'], params={'symbols':','.join(symbol).upper(), 'interval':interval, 'span':span})
+        return res.json()
+        
+    def get_news(self, symbol):
+        return self.session.get(self.endpoints['news']+symbol.upper()+"/").json()
+        
 
     def print_quote(self, stock=None):
         data = self.quote_data(stock)

--- a/Robinhood.py
+++ b/Robinhood.py
@@ -97,7 +97,7 @@ class Robinhood:
         url = str(self.endpoints['quotes']) + str(stock) + "/"
         #Check for validity of symbol
         try:
-            res = json.loads((urllib.request.urlopen(url)).read());
+            res = json.loads((urllib.request.urlopen(url)).read().decode('utf-8'));
             if len(res) > 0:
                 return res;
             else:

--- a/Robinhood.py
+++ b/Robinhood.py
@@ -202,7 +202,7 @@ class Robinhood:
 
     def positions(self):
         """Returns the user's positions data."""
-        return self.session.get(self.endpoints['positions']).json()['results']
+        return self.session.get(self.endpoints['positions']).json()
 
     def securities_owned(self):
         """
@@ -211,7 +211,7 @@ class Robinhood:
         """
         positions = self.positions()
         securities = []
-        for position in positions:
+        for position in positions['results']:
             quantity = float(position['quantity'])
             if quantity > 0:
                 securities.append(self.session.get(position['instrument']).json()['symbol'])


### PR DESCRIPTION
* Added a method `get_historical_quotes (symbol, interval, span, bound)`

For 1 day or 1 week : interval = 5minute | 10minute + span = day, week
For 1 Year : interval = day + span = year
For 5 Year : interval = week

bound = 'regular' (default) | 'extended' (for extended hour quotes)

* Added a method `get_news(symbol)`

* `positions` method previously only retuned the `results` array. The `next` and `previous` attributes were inaccessable. Thus paginated data was inaccessable. The method now returns the entire JSON response form the `positions` endpoint.

* `securities_owened` is modified to work with the new `positions` method.