### PR TITLE
Made Robinhood.py Python 2 compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ See this [blog post](https://medium.com/@rohanpai25/reversing-robinhood-free-acc
 ###How To Install:
     pip install -r requirements.txt
     
+###Converting to Python 3
+By default, this module is written in Python 2.  For users who wish to use the module in Python 3, use the following command:
+    
+    2to3 -w Robinhood.py
 
 ###How to Use (see [example.py](https://github.com/MeheLLC/Robinhood/blob/master/example.py))
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ See this [blog post](https://medium.com/@rohanpai25/reversing-robinhood-free-acc
 ###How To Install:
     pip install -r requirements.txt
     
-###Converting to Python 3
-By default, this module is written in Python 2.  For users who wish to use the module in Python 3, use the following command:
-    
-    2to3 -w Robinhood.py
 
 ###How to Use (see [example.py](https://github.com/MeheLLC/Robinhood/blob/master/example.py))
 

--- a/Robinhood.py
+++ b/Robinhood.py
@@ -49,7 +49,7 @@ class Robinhood:
 
     def __init__(self):
         self.session = requests.session()
-        self.session.proxies = urllib.request.getproxies()
+        self.session.proxies = urllib.getproxies()
         self.headers = {
             "Accept": "*/*",
             "Accept-Encoding": "gzip, deflate",
@@ -99,7 +99,7 @@ class Robinhood:
         url = str(self.endpoints['quotes']) + str(stock) + "/"
         #Check for validity of symbol
         try:
-            res = json.loads((urllib.request.urlopen(url)).read().decode('utf-8'));
+            res = json.loads((urllib.urlopen(url)).read().decode('utf-8'));
             if len(res) > 0:
                 return res;
             else:

--- a/Robinhood.py
+++ b/Robinhood.py
@@ -2,7 +2,7 @@
 import getpass
 import json
 import requests
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 class Robinhood:
 
@@ -63,14 +63,14 @@ class Robinhood:
 
     def login_prompt(self):
         """Prompts user for username and password and calls login()."""
-        username = raw_input("Username: ")
+        username = input("Username: ")
         password = getpass.getpass()
         return self.login(username=username, password=password)
 
     def login(self, username, password):
         self.username = username
         self.password = password
-        data = urllib.urlencode({"password" : self.password, "username" : self.username})
+        data = urllib.parse.urlencode({"password" : self.password, "username" : self.username})
         res = self.session.post(self.endpoints['login'], data=data)
         res = res.json()
         try:
@@ -95,7 +95,7 @@ class Robinhood:
     def quote_data(self, stock=None):
         #Prompt for stock if not entered
         if stock is None:
-            stock = raw_input("Symbol: ");
+            stock = input("Symbol: ");
         url = str(self.endpoints['quotes']) + str(stock) + "/"
         #Check for validity of symbol
         try:
@@ -241,7 +241,7 @@ class Robinhood:
             bid_price = self.quote_data(instrument['symbol'])['bid_price']
         data = 'account=%s&instrument=%s&price=%f&quantity=%d&side=%s&symbol=%s&time_in_force=gfd&trigger=immediate&type=market' % (
             self.get_account()['url'],
-            urllib.unquote(instrument['url']),
+            urllib.parse.unquote(instrument['url']),
             float(bid_price),
             quantity,
             transaction,

--- a/Robinhood.py
+++ b/Robinhood.py
@@ -2,7 +2,7 @@
 import getpass
 import json
 import requests
-import urllib.request, urllib.parse, urllib.error
+import urllib
 
 class Robinhood:
 
@@ -63,14 +63,14 @@ class Robinhood:
 
     def login_prompt(self):
         """Prompts user for username and password and calls login()."""
-        username = input("Username: ")
+        username = raw_input("Username: ")
         password = getpass.getpass()
         return self.login(username=username, password=password)
 
     def login(self, username, password):
         self.username = username
         self.password = password
-        data = urllib.parse.urlencode({"password" : self.password, "username" : self.username})
+        data = urllib.urlencode({"password" : self.password, "username" : self.username})
         res = self.session.post(self.endpoints['login'], data=data)
         res = res.json()
         try:
@@ -95,7 +95,7 @@ class Robinhood:
     def quote_data(self, stock=None):
         #Prompt for stock if not entered
         if stock is None:
-            stock = input("Symbol: ");
+            stock = raw_input("Symbol: ");
         url = str(self.endpoints['quotes']) + str(stock) + "/"
         #Check for validity of symbol
         try:
@@ -241,7 +241,7 @@ class Robinhood:
             bid_price = self.quote_data(instrument['symbol'])['bid_price']
         data = 'account=%s&instrument=%s&price=%f&quantity=%d&side=%s&symbol=%s&time_in_force=gfd&trigger=immediate&type=market' % (
             self.get_account()['url'],
-            urllib.parse.unquote(instrument['url']),
+            urllib.unquote(instrument['url']),
             float(bid_price),
             quantity,
             transaction,


### PR DESCRIPTION
The Robinhood.py file has been fixed to be Python 2 compliant.

However, converting Python 3 with the instructions won't entirely work since, for some reason, the 2to3 won't pick up urllib.getproxies() to urllib.request.getproxies().  That change has to be done manually.