### PR TITLE
for py3: "import exceptions"

### DIFF
--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -11,7 +11,7 @@ from six.moves.urllib.request import getproxies
 from six.moves import input
 
 if six.PY3: #pragma: no cover
-    import Robinhood.exceptions as RH_exception
+    import exceptions as RH_exception
 else:       #pragma: no cover
     import exceptions as RH_exception
 


### PR DESCRIPTION
change "import Robinhood.exceptions" to "import exceptions" for python 3