### PR TITLE
paging support for instruments

### DIFF
--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -185,6 +185,11 @@ class Robinhood:
         )
         res.raise_for_status()
         res = res.json()
+        
+        # if requesting all, return entire object so may paginate with ['next'] 
+        if (stock == ""):
+            return res
+        
         return res['results']
 
     def quote_data(self, stock=''):


### PR DESCRIPTION
This is a trivial but important backward compatible fix to the `instruments` wrapper to allow for paging (by returning `'next'` field if no symbol passed in).  Paging for `instruments` endpoint is supported when no symbol is passed in, allowing the user to enumerate available instruments.  Existing users of this who pass in a symbol are unaffected.  The small change has been unit tested.