### PR TITLE
Fix get historical stock ticker data request

### DIFF
--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -307,7 +307,6 @@ class Robinhood:
         data = self.quote_data(stock)
         return data["symbol"]
 
-
     def get_historical_quotes(self, stock, interval, span, bounds=Bounds.REGULAR):
         """Fetch historical data for stock
 
@@ -326,12 +325,14 @@ class Robinhood:
             Returns:
                 (:obj:`dict`) values returned from `historicals` endpoint
         """
+        if type(stock) is str:
+            stock = [stock]
 
-        if isinstance(bounds, str): #recast to Enum
+        if isinstance(bounds, str):  # recast to Enum
             bounds = Bounds(bounds)
 
         params = {
-            'symbols': ','.join(stock).upper,
+            'symbols': ','.join(stock).upper(),
             'interval': interval,
             'span': span,
             'bounds': bounds.name.lower()

--- a/tests/test_getdata.py
+++ b/tests/test_getdata.py
@@ -229,3 +229,30 @@ def test_intstruments(config=CONFIG):
     data = Robinhood().instruments(CONFIG.get('FETCH', 'test_ticker'))
 
     assert data == hard_data
+
+def test_get_historical_data(config=CONFIG):
+    headers = {
+        'User-Agent': CONFIG.get('FETCH', 'user_agent')
+    }
+
+    address = Robinhood().endpoints['historicals']
+    res = requests.get(
+        address,
+        headers=headers,
+        params={
+            'symbols': ','.join([CONFIG.get('FETCH', 'test_ticker')]).upper(),
+            'interval': 'day',
+            'span': 'year',
+            'bounds': 'regular'
+        }
+    )
+
+    hard_data = res.json()['results']
+
+    data = Robinhood().get_historical_quotes(
+        [CONFIG.get('FETCH', 'test_ticker')],
+        'day',
+        'year'
+    )
+
+    assert data == hard_data


### PR DESCRIPTION
The get historical data function call was failing because the uppercase string function itself was being referenced, rather than the result of it. Additionally, passing in a singular stock would result in an error due to the string being split. 