### PR TITLE
Add instrument() API to fetch instrument by id

### DIFF
--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -201,6 +201,27 @@ class Robinhood:
         return res['results']
 
 
+    def instrument(self, id):
+        """Fetch instrument info
+
+            Args:
+                id (str): instrument id
+
+            Returns:
+                (:obj:`dict`): JSON dict of instrument
+        """
+        url = str(self.endpoints['instruments']) + str(id) + "/"
+
+        try:
+            req = requests.get(url)
+            req.raise_for_status()
+            data = req.json()
+        except requests.exceptions.HTTPError:
+            raise RH_exception.InvalidInstrumentId()
+
+        return data
+
+
     def quote_data(self, stock=''):
         """Fetch stock quote
 

--- a/Robinhood/exceptions.py
+++ b/Robinhood/exceptions.py
@@ -32,3 +32,10 @@ class InvalidTickerSymbol(RobinhoodException):
     """
 
     pass
+
+
+class InvalidInstrumentId(RobinhoodException):
+    """
+        When an invalid instrument id is given
+    """
+    pass


### PR DESCRIPTION
Expanding functionality for **instruments** endpoint.
Implements the following call: [Gather Basic Instrument Info by ID](https://github.com/sanko/Robinhood/blob/master/Instrument.md#gather-basic-instrument-info-by-id)