### PR TITLE
Fix version number to be consistent with the recent release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
 HERE = path.abspath(path.dirname(__file__))
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 REQUIRES = [
     'requests>=2.13.0,<=2.18.4',


### PR DESCRIPTION
Because of the stale version number in `setup.py`, the egg file uses a wrong version number, 1.0.0 rather than 1.0.1. This change updates it to the version number of the most recent release.