### PR TITLE
Popularity

### DIFF
--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -61,7 +61,7 @@ class Robinhood:
         "user": "https://api.robinhood.com/user/",
         "watchlists": "https://api.robinhood.com/watchlists/",
         "news": "https://api.robinhood.com/midlands/news/",
-        "fundamentals": "https://api.robinhood.com/fundamentals/",
+        "fundamentals": "https://api.robinhood.com/fundamentals/"
     }
 
     session = None
@@ -610,7 +610,19 @@ class Robinhood:
         """
 
         return self.session.get(url, timeout=15).json()
+    
+    def get_popularity(self, stock=''):
+        """Get the number of robinhood users who own the given stock
+            
+            Args:
+                stock (str): stock ticker
 
+            Returns:
+                (int): number of users who own the stock
+        """
+        stock_instrument = self.instruments(stock)[0]["id"]
+        url = "{base}{instrument}/popularity/".format(base=self.endpoints['instruments'],instrument=stock_instrument)
+        return self.session.get(url, timeout=15).json()["num_open_positions"]
 
     ###########################################################################
     #                           GET FUNDAMENTALS

--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -622,8 +622,7 @@ class Robinhood:
                 (int): number of users who own the stock
         """
         stock_instrument = self.instruments(stock)[0]["id"]
-        url = "{base}{instrument}/popularity/".format(base=self.endpoints['instruments'],instrument=stock_instrument)
-        return self.session.get(url, timeout=15).json()["num_open_positions"]
+        return self.get_url("{base}{instrument}/popularity/".format(base=self.endpoints['instruments'], instrument=stock_instrument))["num_open_positions"]
 
     def get_tickers_by_tag(self, tag=None):
         """Get a list of instruments belonging to a tag
@@ -640,9 +639,8 @@ class Robinhood:
             Returns:
                 (List): a list of Ticker strings
         """
-        url = "{base}{_tag}/".format(base=self.endpoints['tags'], _tag=tag)
-        instrument_list = self.session.get(url, timeout=15).json()["instruments"]
-        return [self.session.get(instrument, timeout=15).json()["symbol"] for instrument in instrument_list]
+        instrument_list = self.get_url("{base}{_tag}/".format(base=self.endpoints['tags'], _tag=tag))["instruments"]
+        return [self.get_url(instrument)["symbol"] for instrument in instrument_list]
 
 
     ###########################################################################

--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -62,7 +62,7 @@ class Robinhood:
         "watchlists": "https://api.robinhood.com/watchlists/",
         "news": "https://api.robinhood.com/midlands/news/",
         "fundamentals": "https://api.robinhood.com/fundamentals/",
-        "top_movers": "https://api.robinhood.com/midlands/tags/tag/top-movers/"
+        "tags": "https://api.robinhood.com/midlands/tags/tag/"
     }
 
     session = None
@@ -625,15 +625,23 @@ class Robinhood:
         url = "{base}{instrument}/popularity/".format(base=self.endpoints['instruments'],instrument=stock_instrument)
         return self.session.get(url, timeout=15).json()["num_open_positions"]
 
-    def top_movers(self):
-        """Get a list of the top movers
+    def get_tickers_by_tag(self, tag=None):
+        """Get a list of instruments belonging to a tag
             
-            Args: None
+            Args: tag - a string that equals one of the following:
+                * top-movers
+                * etf
+                * 100-most-popular
+                * mutual-fund
+                * finance
+                * cap-weighted
+                * investment-trust-or-fund
 
             Returns:
                 (List): a list of Ticker strings
         """
-        instrument_list = self.session.get(self.endpoints['top_movers'], timeout=15).json()["instruments"]
+        url = "{base}{_tag}/".format(base=self.endpoints['tags'], _tag=tag)
+        instrument_list = self.session.get(url, timeout=15).json()["instruments"]
         return [self.session.get(instrument, timeout=15).json()["symbol"] for instrument in instrument_list]
 
 

--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -621,7 +621,7 @@ class Robinhood:
             Returns:
                 (int): number of users who own the stock
         """
-        stock_instrument = self.instruments(stock)[0]["id"]
+        stock_instrument = self.get_url(self.quote_data(stock)["instrument"])["id"]
         return self.get_url("{base}{instrument}/popularity/".format(base=self.endpoints['instruments'], instrument=stock_instrument))["num_open_positions"]
 
     def get_tickers_by_tag(self, tag=None):

--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -61,7 +61,8 @@ class Robinhood:
         "user": "https://api.robinhood.com/user/",
         "watchlists": "https://api.robinhood.com/watchlists/",
         "news": "https://api.robinhood.com/midlands/news/",
-        "fundamentals": "https://api.robinhood.com/fundamentals/"
+        "fundamentals": "https://api.robinhood.com/fundamentals/",
+        "top_movers": "https://api.robinhood.com/midlands/tags/tag/top-movers/"
     }
 
     session = None
@@ -623,6 +624,18 @@ class Robinhood:
         stock_instrument = self.instruments(stock)[0]["id"]
         url = "{base}{instrument}/popularity/".format(base=self.endpoints['instruments'],instrument=stock_instrument)
         return self.session.get(url, timeout=15).json()["num_open_positions"]
+
+    def top_movers(self):
+        """Get a list of the top movers
+            
+            Args: None
+
+            Returns:
+                (List): a list of Ticker strings
+        """
+        instrument_list = self.session.get(self.endpoints['top_movers'], timeout=15).json()["instruments"]
+        return [self.session.get(instrument, timeout=15).json()["symbol"] for instrument in instrument_list]
+
 
     ###########################################################################
     #                           GET FUNDAMENTALS


### PR DESCRIPTION
In response to [issue #79 ](https://github.com/Jamonek/Robinhood/issues/79). 

I've added a popularity method that pulls information from the instruments endpoint to return the number of Robinhood users who own a given ticker. 

I've also added an endpoint and a method for "Top Movers" that returns the list of tickers for the top moving instruments that is now a component on the Robinhood Web interface.