### PR TITLE
ENHANCE: abstracted endpoints to separate module, refactor 2 methods

### DIFF
--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -17,6 +17,7 @@ import six
 
 #Application-specific imports
 from . import exceptions as RH_exception
+from . import endpoints
 
 
 class Bounds(Enum):
@@ -622,12 +623,12 @@ class Robinhood:
                 (int): number of users who own the stock
         """
         stock_instrument = self.get_url(self.quote_data(stock)["instrument"])["id"]
-        return self.get_url("{base}{instrument}/popularity/".format(base=self.endpoints['instruments'], instrument=stock_instrument))["num_open_positions"]
+        return self.get_url(endpoints.instruments(stock_instrument, "popularity"))["num_open_positions"]
 
     def get_tickers_by_tag(self, tag=None):
         """Get a list of instruments belonging to a tag
             
-            Args: tag - a string that equals one of the following:
+            Args: tag - Tags may include but are not limited to:
                 * top-movers
                 * etf
                 * 100-most-popular
@@ -639,7 +640,7 @@ class Robinhood:
             Returns:
                 (List): a list of Ticker strings
         """
-        instrument_list = self.get_url("{base}{_tag}/".format(base=self.endpoints['tags'], _tag=tag))["instruments"]
+        instrument_list = self.get_url(endpoints.tags(tag))["instruments"]
         return [self.get_url(instrument)["symbol"] for instrument in instrument_list]
 
 

--- a/Robinhood/endpoints.py
+++ b/Robinhood/endpoints.py
@@ -17,10 +17,7 @@ def ach(option):
         * relationships
         * transfers
     '''
-    if(option == "iav"):
-        return "https://api.robinhood.com/ach/iav/auth/"
-    else:
-        return "https://api.robinhood.com/ach/{_option}/".format(_option=option)
+    return "https://api.robinhood.com/ach/iav/auth/" if option == "iav" else "https://api.robinhood.com/ach/{_option}/".format(_option=option)
 
 def applications():
     return "https://api.robinhood.com/applications/"
@@ -36,7 +33,7 @@ def instruments(instrumentId=None, option=None):
     Return information about a specific instrument by providing its instrument id. 
     Add extra options for additional information such as "popularity"
     '''
-    return "https://api.robinhood.com/instruments/{id}/{_option}/".format(id=instrumentId, _option=option) if option else "https://api.robinhood.com/instruments/{id}/".format(id=instrumentId) 
+    return "https://api.robinhood.com/instruments/{id}/".format(id=instrumentId) + "{_option}/".format(_option=option) if option else ""
 
 def margin_upgrades():
     return "https://api.robinhood.com/margin/upgrades/"

--- a/Robinhood/endpoints.py
+++ b/Robinhood/endpoints.py
@@ -1,0 +1,87 @@
+def login():
+    return "https://api.robinhood.com/api-token-auth/"
+
+def logout():
+    return "https://api.robinhood.com/api-token-logout/"
+
+def investment_profile():
+    return "https://api.robinhood.com/user/investment_profile/"
+
+def accounts():
+    return "https://api.robinhood.com/accounts/"
+
+def ach(option):
+    '''
+    Combination of 3 ACH endpoints. Options include:
+        * iav
+        * relationships
+        * transfers
+    '''
+    if(option == "iav"):
+        return "https://api.robinhood.com/ach/iav/auth/"
+    else:
+        return "https://api.robinhood.com/ach/{_option}/".format(_option=option)
+
+def applications():
+    return "https://api.robinhood.com/applications/"
+
+def dividends():
+    return "https://api.robinhood.com/dividends/"
+
+def edocuments():
+    return "https://api.robinhood.com/documents/"
+
+def instruments(instrumentId=None, option=None):
+    '''
+    Return information about a specific instrument by providing its instrument id. 
+    Add extra options for additional information such as "popularity"
+    '''
+    return "https://api.robinhood.com/instruments/{id}/{_option}/".format(id=instrumentId, _option=option) if option else "https://api.robinhood.com/instruments/{id}/".format(id=instrumentId) 
+
+def margin_upgrades():
+    return "https://api.robinhood.com/margin/upgrades/"
+
+def markets():
+    return "https://api.robinhood.com/markets/"
+
+def notifications():
+    return "https://api.robinhood.com/notifications/"
+
+def orders():
+    return "https://api.robinhood.com/orders/"
+
+def password_reset():
+    return "https://api.robinhood.com/password_reset/request/"
+
+def portfolios():
+    return "https://api.robinhood.com/portfolios/"
+
+def positions():
+    return "https://api.robinhood.com/positions/"
+
+def quotes():
+    return "https://api.robinhood.com/quotes/"
+
+def historicals():
+    return "https://api.robinhood.com/quotes/historicals/"
+
+def document_requests():
+    return "https://api.robinhood.com/upload/document_requests/"
+
+def user():
+    return "https://api.robinhood.com/user/"
+
+def watchlists():
+    return "https://api.robinhood.com/watchlists/"
+
+def news():
+    return "https://api.robinhood.com/midlands/news/"
+
+def fundamentals():
+    return "https://api.robinhood.com/fundamentals/"
+
+def tags(tag=None):
+    '''
+    Returns endpoint with tag concatenated.
+    '''
+    return "https://api.robinhood.com/midlands/tags/tag/{_tag}/".format(_tag=tag)


### PR DESCRIPTION
The purpose of this pull request is to abstract the endpoint dictionary into a separate module of functions that can be modified as the Robinhood API grows. I intend to contribute functionality for new options endpoints that I have discovered but the current dictionary would require several iterations of the same endpoint for the right functionality.

See get_popularity() and get_tickers_by_tag() for examples of how these new endpoints functions have been implemented in the main module. Also see the ach() function in the endpoints.py file to see how abstracting the endpoints can make this library more flexible, allowing the combination of 3 dictionary items into 1 function.