### PR TITLE
Add Options info and Options Market data info

### DIFF
--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -622,8 +622,7 @@ class Robinhood:
                 (int): number of users who own the stock
         """
         stock_instrument = self.instruments(stock)[0]["id"]
-        url = "{base}{instrument}/popularity/".format(base=self.endpoints['instruments'],instrument=stock_instrument)
-        return self.session.get(url, timeout=15).json()["num_open_positions"]
+        return self.get_url("{base}{instrument}/popularity/".format(base=self.endpoints['instruments'], instrument=stock_instrument))["num_open_positions"]
 
     def get_tickers_by_tag(self, tag=None):
         """Get a list of instruments belonging to a tag
@@ -640,9 +639,8 @@ class Robinhood:
             Returns:
                 (List): a list of Ticker strings
         """
-        url = "{base}{_tag}/".format(base=self.endpoints['tags'], _tag=tag)
-        instrument_list = self.session.get(url, timeout=15).json()["instruments"]
-        return [self.session.get(instrument, timeout=15).json()["symbol"] for instrument in instrument_list]
+        instrument_list = self.get_url("{base}{_tag}/".format(base=self.endpoints['tags'], _tag=tag))["instruments"]
+        return [self.get_url(instrument)["symbol"] for instrument in instrument_list]
 
 
     ###########################################################################

--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -133,7 +133,7 @@ class Robinhood:
             payload['mfa_code'] = mfa_code
 
         try:
-            res = self.session.post(self.endpoints['login'], data=payload, timeout=15)
+            res = self.session.post(endpoints.login(), data=payload, timeout=15)
             res.raise_for_status()
             data = res.json()
         except requests.exceptions.HTTPError:
@@ -159,7 +159,7 @@ class Robinhood:
         """
 
         try:
-            req = self.session.post(self.endpoints['logout'], timeout=15)
+            req = self.session.post(endpoints.logout(), timeout=15)
             req.raise_for_status()
         except requests.exceptions.HTTPError as err_msg:
             warnings.warn('Failed to log out ' + repr(err_msg))
@@ -177,7 +177,7 @@ class Robinhood:
     def investment_profile(self):
         """Fetch investment_profile """
 
-        res = self.session.get(self.endpoints['investment_profile'], timeout=15)
+        res = self.session.get(endpoints.investment_profile(), timeout=15)
         res.raise_for_status()  #will throw without auth
         data = res.json()
 
@@ -194,7 +194,7 @@ class Robinhood:
                 (:obj:`dict`): JSON contents from `instruments` endpoint
         """
 
-        res = self.session.get(self.endpoints['instruments'], params={'query': stock.upper()}, timeout=15)
+        res = self.session.get(endpoints.instruments(), params={'query': stock.upper()}, timeout=15)
         res.raise_for_status()
         res = res.json()
 
@@ -214,7 +214,7 @@ class Robinhood:
             Returns:
                 (:obj:`dict`): JSON dict of instrument
         """
-        url = str(self.endpoints['instruments']) + str(id) + "/"
+        url = str(endpoints.instruments()) + str(id) + "/"
 
         try:
             req = requests.get(url, timeout=15)
@@ -239,9 +239,9 @@ class Robinhood:
         url = None
 
         if stock.find(',') == -1:
-            url = str(self.endpoints['quotes']) + str(stock) + "/"
+            url = str(endpoints.quotes()) + str(stock) + "/"
         else:
-            url = str(self.endpoints['quotes']) + "?symbols=" + str(stock)
+            url = str(endpoints.quotes()) + "?symbols=" + str(stock)
 
         #Check for validity of symbol
         try:
@@ -267,7 +267,7 @@ class Robinhood:
                     same order of input args. If any ticker is invalid, a None will occur at that position.
         """
 
-        url = str(self.endpoints['quotes']) + "?symbols=" + ",".join(stocks)
+        url = str(endpoints.quotes()) + "?symbols=" + ",".join(stocks)
 
         try:
             req = requests.get(url, timeout=15)
@@ -363,7 +363,7 @@ class Robinhood:
             'bounds': bounds.name.lower()
         }
 
-        res = self.session.get(self.endpoints['historicals'], params=params, timeout=15)
+        res = self.session.get(endpoints.historicals(), params=params, timeout=15)
         return res.json()
 
 
@@ -376,7 +376,7 @@ class Robinhood:
                 (:obj:`dict`) values returned from `news` endpoint
         """
 
-        return self.session.get(self.endpoints['news'] + stock.upper() + "/", timeout=15).json()
+        return self.session.get(endpoints.news(stock.upper()), timeout=15).json()
 
 
     def print_quote(self, stock=''):    #pragma: no cover
@@ -601,7 +601,7 @@ class Robinhood:
                 (:obj:`dict`): `accounts` endpoint payload
         """
 
-        res = self.session.get(self.endpoints['accounts'], timeout=15)
+        res = self.session.get(endpoints.accounts(), timeout=15)
         res.raise_for_status()  #auth required
         res = res.json()
 
@@ -684,7 +684,7 @@ class Robinhood:
         if not stock:   #pragma: no cover
             stock = input("Symbol: ")
 
-        url = str(self.endpoints['fundamentals']) + str(stock.upper()) + "/"
+        url = str(endpoints.fundamentals(str(stock.upper())))
 
         #Check for validity of symbol
         try:
@@ -711,7 +711,7 @@ class Robinhood:
     def portfolios(self):
         """Returns the user's portfolio data """
 
-        req = self.session.get(self.endpoints['portfolios'], timeout=15)
+        req = self.session.get(endpoints.portfolios(), timeout=15)
         req.raise_for_status()
 
         return req.json()['results'][0]
@@ -821,7 +821,7 @@ class Robinhood:
                 (:obj:`dict`): JSON dict from getting orders
         """
 
-        return self.session.get(self.endpoints['orders'], timeout=15).json()
+        return self.session.get(endpoints.orders(), timeout=15).json()
 
 
     def dividends(self):
@@ -831,7 +831,7 @@ class Robinhood:
                 (:obj: `dict`): JSON dict from getting dividends
         """
 
-        return self.session.get(self.endpoints['dividends'], timeout=15).json()
+        return self.session.get(endpoints.dividends(), timeout=15).json()
 
 
     ###########################################################################
@@ -845,7 +845,7 @@ class Robinhood:
                 (:object: `dict`): JSON dict from getting positions
         """
 
-        return self.session.get(self.endpoints['positions'], timeout=15).json()
+        return self.session.get(endpoints.positions(), timeout=15).json()
 
 
     def securities_owned(self):
@@ -855,7 +855,7 @@ class Robinhood:
                 (:object: `dict`): Non-zero positions
         """
 
-        return self.session.get(self.endpoints['positions']+'?nonzero=true', timeout=15).json()
+        return self.session.get(endpoints.positions()+'?nonzero=true', timeout=15).json()
 
 
     ###########################################################################
@@ -919,7 +919,7 @@ class Robinhood:
         #    instrument['symbol']
         #)
 
-        res = self.session.post(self.endpoints['orders'], data=payload, timeout=15)
+        res = self.session.post(endpoints.orders(), data=payload, timeout=15)
         res.raise_for_status()
 
         return res
@@ -1335,7 +1335,7 @@ class Robinhood:
             if(value is not None):
                 payload[field] = value
 
-        res = self.session.post(self.endpoints['orders'], data=payload, timeout=15)
+        res = self.session.post(endpoints.orders(), data=payload, timeout=15)
         res.raise_for_status()
 
         return res

--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -667,6 +667,12 @@ class Robinhood:
         return [contract for contract in self.get_url(endpoints.options(chain_id, _expiration_dates_string, option_type))["results"]]
 
     def get_option_market_data(self, optionid):
+        """Gets a list of market data for a given optionid.
+
+        Args: (str) option id
+
+        Returns: dictionary of options market data.
+        """
         if not self.oauth_token:
             res = self.session.post(endpoints.convert_token(), timeout=15)
             res.raise_for_status()

--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -62,7 +62,9 @@ class Robinhood:
         "watchlists": "https://api.robinhood.com/watchlists/",
         "news": "https://api.robinhood.com/midlands/news/",
         "fundamentals": "https://api.robinhood.com/fundamentals/",
-        "tags": "https://api.robinhood.com/midlands/tags/tag/"
+        "tags": "https://api.robinhood.com/midlands/tags/tag/",
+        "oath2": "https://api.robinhood.com/oauth2/migrate_token/",
+        "options": "https://api.robinhood.com/options/"
     }
 
     session = None
@@ -641,6 +643,27 @@ class Robinhood:
         """
         instrument_list = self.get_url("{base}{_tag}/".format(base=self.endpoints['tags'], _tag=tag))["instruments"]
         return [self.get_url(instrument)["symbol"] for instrument in instrument_list]
+
+    ###########################################################################
+    #                           GET OPTIONS INFO
+    ###########################################################################
+
+    def get_options(self, instrument, expiration_dates, option_type):
+        """Get a list (chain) of options contracts belonging to a particular instrument
+            
+            Args: instrument id (str), list of expiration dates to filter on (YYYY-MM-DD), and whether or not its a 'put' or a 'call' option type (str).
+
+            Returns:
+                Options Contracts (List): a list (chain) of contract ids that can be queried for additional 
+                information about that options contract.
+        """
+        if(type(expiration_dates) == list):
+            _expiration_dates_string = expiration_dates.join(",")
+        else:
+            _expiration_dates_string = expiration_dates
+        chain_id = self.get_url("{base}chains/?equity_instrument_ids={_instrument}".format(base=self.endpoints['options'], _instrument=instrument))["results"][0]["id"]
+        options_url = "{base}instruments/?chain_id={_chainid}&expiration_dates={_dates}&state=active&tradability=tradable&type={_type}".format(base=self.endpoints['options'], _chainid=chain_id, _dates=_expiration_dates_string, _type=option_type)
+        return [contract["id"] for contract in self.get_url(options_url)["results"]]
 
 
     ###########################################################################

--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -654,8 +654,7 @@ class Robinhood:
             Args: instrument id (str), list of expiration dates to filter on (YYYY-MM-DD), and whether or not its a 'put' or a 'call' option type (str).
 
             Returns:
-                Options Contracts (List): a list (chain) of contract ids that can be queried for additional 
-                information about that options contract.
+                Options Contracts (List): a list (chain) of contracts for a given underlying equity instrument
         """
         if(type(expiration_dates) == list):
             _expiration_dates_string = expiration_dates.join(",")
@@ -663,7 +662,7 @@ class Robinhood:
             _expiration_dates_string = expiration_dates
         chain_id = self.get_url("{base}chains/?equity_instrument_ids={_instrument}".format(base=self.endpoints['options'], _instrument=instrument))["results"][0]["id"]
         options_url = "{base}instruments/?chain_id={_chainid}&expiration_dates={_dates}&state=active&tradability=tradable&type={_type}".format(base=self.endpoints['options'], _chainid=chain_id, _dates=_expiration_dates_string, _type=option_type)
-        return [contract["id"] for contract in self.get_url(options_url)["results"]]
+        return [contract for contract in self.get_url(options_url)["results"]]
 
 
     ###########################################################################

--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -621,7 +621,7 @@ class Robinhood:
             Returns:
                 (int): number of users who own the stock
         """
-        stock_instrument = self.instruments(stock)[0]["id"]
+        stock_instrument = self.get_url(self.quote_data(stock)["instrument"])["id"]
         return self.get_url("{base}{instrument}/popularity/".format(base=self.endpoints['instruments'], instrument=stock_instrument))["num_open_positions"]
 
     def get_tickers_by_tag(self, tag=None):

--- a/Robinhood/endpoints.py
+++ b/Robinhood/endpoints.py
@@ -91,3 +91,6 @@ def options(chainid, dates, option_type):
 
 def market_data(optionid):
     return "https://api.robinhood.com/marketdata/options/{_optionid}/".format(_optionid=optionid)
+
+def convert_token():
+    return "https://api.robinhood.com/oauth2/migrate_token/"

--- a/Robinhood/endpoints.py
+++ b/Robinhood/endpoints.py
@@ -82,3 +82,12 @@ def tags(tag=None):
     Returns endpoint with tag concatenated.
     '''
     return "https://api.robinhood.com/midlands/tags/tag/{_tag}/".format(_tag=tag)
+
+def chain(instrumentid):
+    return "https://api.robinhood.com/options/chains/?equity_instrument_ids={_instrumentid}".format(_instrumentid=instrumentid)
+
+def options(chainid, dates, option_type):
+    return "https://api.robinhood.com/options/instruments/?chain_id={_chainid}&expiration_dates={_dates}&state=active&tradability=tradable&type={_type}".format(_chainid=chainid, _dates=dates, _type=option_type)
+
+def market_data(optionid):
+    return "https://api.robinhood.com/marketdata/options/{_optionid}/".format(_optionid=optionid)

--- a/Robinhood/endpoints.py
+++ b/Robinhood/endpoints.py
@@ -71,11 +71,11 @@ def user():
 def watchlists():
     return "https://api.robinhood.com/watchlists/"
 
-def news():
-    return "https://api.robinhood.com/midlands/news/"
+def news(stock):
+    return "https://api.robinhood.com/midlands/news/{_stock}/".format(_stock=stock)
 
-def fundamentals():
-    return "https://api.robinhood.com/fundamentals/"
+def fundamentals(stock):
+    return "https://api.robinhood.com/fundamentals/{_stock}/".format(_stock=stock)
 
 def tags(tag=None):
     '''

--- a/docs/example.py
+++ b/docs/example.py
@@ -1,7 +1,7 @@
 from Robinhood import Robinhood
 
 #Setup
-my_trader = Robinhood();
+my_trader = Robinhood()
 #login
 my_trader.login(username="YOUR_USERNAME", password="YOUR_PASSWORD")
 
@@ -13,14 +13,14 @@ stock_instrument = my_trader.instruments("GEVO")[0]
 my_trader.print_quote("AAPL")
 
 #Prompt for a symbol
-my_trader.print_quote();
+my_trader.print_quote()
 
 #Print multiple symbols
 my_trader.print_quotes(stocks=["BBRY", "FB", "MSFT"])
 
 #View all data for a given stock ie. Ask price and size, bid price and size, previous close, adjusted previous close, etc.
 quote_info = my_trader.quote_data("GEVO")
-print(quote_info);
+print(quote_info)
 
 #Place a buy order (uses market bid price)
 buy_order = my_trader.place_buy_order(stock_instrument, 1)


### PR DESCRIPTION
Addresses [issue #86 ](https://github.com/Jamonek/Robinhood/issues/86)

Building off of [pull request #84 ](https://github.com/Jamonek/Robinhood/pull/84) to abstract endpoints, this pull request adds options specific endpoints and additional methods to use them in the main class.

It also adds an endpoint to convert standard tokens to oauth2 tokens which is required to obtain options market data. When requesting market data the normal Authorization header will be automatically modified to use the oauth2 token which will supersede the need for the standard token (although the oauth2 token does it expire whereas the standard token does not).

This pull request is only meant as a baseline for future options functionality, feedback welcome. 