### PR TITLE
BUG FIX: instruments endpoint

### DIFF
--- a/Robinhood/endpoints.py
+++ b/Robinhood/endpoints.py
@@ -33,7 +33,7 @@ def instruments(instrumentId=None, option=None):
     Return information about a specific instrument by providing its instrument id. 
     Add extra options for additional information such as "popularity"
     '''
-    return "https://api.robinhood.com/instruments/{id}/".format(id=instrumentId) + "{_option}/".format(_option=option) if option else ""
+    return "https://api.robinhood.com/instruments/" + ("{id}/".format(id=instrumentId) if instrumentId else "") + ("{_option}/".format(_option=option) if option else "")
 
 def margin_upgrades():
     return "https://api.robinhood.com/margin/upgrades/"


### PR DESCRIPTION
This is in response to @rambutan2000:

> Hi all,  I've just started making a Django app (for personal use) using this api.  I can log into my RH account fine but when I try and pull Instruments data I get:  Invalid URL '': No schema supplied. Perhaps you meant http://?   Callstack says it's from Robinhood.py line 198.  I'm calling Robinhood.instruments the same way as the example  code.  Am I missing something or is this a bug?  PS sorry if this is the wrong place to ask questions

Needed to add an extra condition to the string interpolation if instrumentid was blank so that the URI did not end with double forward slashes.