### PR TITLE
cancel_order fix commit 1

### DIFF
--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -1354,7 +1354,7 @@ class Robinhood:
         """
         if isinstance(order_id, str):
             try:
-                order = self.session.get(self.endpoints['orders'] + order_id, timeout=15).json()
+                order = self.session.get(self.endpoints.orders() + order_id, timeout=15).json()
             except (requests.exceptions.HTTPError) as err_msg:
                 raise ValueError('Failed to get Order for ID: ' + order_id
                     + '\n Error message: '+ repr(err_msg))
@@ -1371,7 +1371,7 @@ class Robinhood:
         if isinstance(order_id, dict):
             order_id = order_id['id']
             try:
-                order = self.session.get(self.endpoints['orders'] + order_id, timeout=15).json()
+                order = self.session.get(self.endpoints.orders() + order_id, timeout=15).json()
             except (requests.exceptions.HTTPError) as err_msg:
                 raise ValueError('Failed to get Order for ID: ' + order_id
                     + '\n Error message: '+ repr(err_msg))

--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -1354,7 +1354,7 @@ class Robinhood:
         """
         if isinstance(order_id, str):
             try:
-                order = self.session.get(self.endpoints.orders() + order_id, timeout=15).json()
+                order = self.session.get(self.endpoints['orders'] + order_id, timeout=15).json()
             except (requests.exceptions.HTTPError) as err_msg:
                 raise ValueError('Failed to get Order for ID: ' + order_id
                     + '\n Error message: '+ repr(err_msg))
@@ -1371,7 +1371,7 @@ class Robinhood:
         if isinstance(order_id, dict):
             order_id = order_id['id']
             try:
-                order = self.session.get(self.endpoints.orders() + order_id, timeout=15).json()
+                order = self.session.get(self.endpoints['orders'] + order_id, timeout=15).json()
             except (requests.exceptions.HTTPError) as err_msg:
                 raise ValueError('Failed to get Order for ID: ' + order_id
                     + '\n Error message: '+ repr(err_msg))

--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -1368,11 +1368,7 @@ class Robinhood:
                          + '\n Error message: '+ repr(err_msg))
                     return None
 
-<<<<<<< HEAD
         if isinstance(order_id, dict):
-=======
-        if order_id is dict:
->>>>>>> b14fa61add1489befd402e0812c5a9a01e2502ec
             order_id = order_id['id']
             try:
                 order = self.session.get(self.endpoints['orders'] + order_id, timeout=15).json()

--- a/Robinhood/Robinhood.py
+++ b/Robinhood/Robinhood.py
@@ -1342,37 +1342,55 @@ class Robinhood:
     def cancel_order(
             self,
             order_id
-    ): 
+    ):
         """
-        Cancels specified order and returns the response (results from `orders` command). 
+        Cancels specified order and returns the response (results from `orders` command).
         If order cannot be cancelled, `None` is returned.
-
         Args:
-            order_id (str): Order ID that is to be cancelled or order dict returned from
+            order_id (str or dict): Order ID string that is to be cancelled or open order dict returned from
             order get.
         Returns:
             (:obj:`requests.request`): result from `orders` put command
         """
-        if order_id is str:
+        if isinstance(order_id, str):
             try:
                 order = self.session.get(self.endpoints['orders'] + order_id, timeout=15).json()
             except (requests.exceptions.HTTPError) as err_msg:
                 raise ValueError('Failed to get Order for ID: ' + order_id
                     + '\n Error message: '+ repr(err_msg))
-        else:
-            raise ValueError('Cancelling orders requires a valid order_id string')
 
-        if order.get('cancel') is not None:
-            try: 
-                res = self.session.post(order['cancel'], timeout=15)
-                res.raise_for_status()
+            if order.get('cancel') is not None:
+                try:
+                    res = self.session.post(order['cancel'], timeout=15)
+                    res.raise_for_status()
+                except (requests.exceptions.HTTPError) as err_msg:
+                    raise ValueError('Failed to cancel order ID: ' + order_id
+                         + '\n Error message: '+ repr(err_msg))
+                    return None
+
+        if isinstance(order_id, dict):
+            order_id = order_id['id']
+            try:
+                order = self.session.get(self.endpoints['orders'] + order_id, timeout=15).json()
             except (requests.exceptions.HTTPError) as err_msg:
-                raise ValueError('Failed to cancel order ID: ' + order_id
-                     + '\n Error message: '+ repr(err_msg))
-                return None
-            
+                raise ValueError('Failed to get Order for ID: ' + order_id
+                    + '\n Error message: '+ repr(err_msg))
+
+            if order.get('cancel') is not None:
+                try:
+                    res = self.session.post(order['cancel'], timeout=15)
+                    res.raise_for_status()
+                except (requests.exceptions.HTTPError) as err_msg:
+                    raise ValueError('Failed to cancel order ID: ' + order_id
+                         + '\n Error message: '+ repr(err_msg))
+                    return None
+
+        elif order_id is not str or dict:
+            raise ValueError('Cancelling orders requires a valid order_id string or open order dictionary')
+
+
         # Order type cannot be cancelled without a valid cancel link
-        else: 
+        else:
             raise ValueError('Unable to cancel order ID: ' + order_id)
 
         return res


### PR DESCRIPTION
I rewrote the cancel_order function, as there was a bug that made it unworkable. There were If Else statements that were out of place and an Else statement that blocked the cancel_order from posting.

I also added the functionality for the open order's dictionary to be passed as well as the order_id string.