### PR TITLE
Bug: Rename rb to rb_client

### DIFF
--- a/Robinhood/trade_history_downloader.py
+++ b/Robinhood/trade_history_downloader.py
@@ -33,7 +33,7 @@ def order_item_info(order, rb_client, db):
 
 def get_all_history_orders(rb_client):
     orders = []
-    past_orders = rb.order_history()
+    past_orders = rb_client.order_history()
     orders.extend(past_orders['results'])
     while past_orders['next']:
         print("{} order fetched".format(len(orders)))


### PR DESCRIPTION
`rb` doesn't exist in this function.  It's supposed to be `rb_client`.