### PR TITLE
Slight update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ See this [blog post](https://medium.com/@rohanpai25/reversing-robinhood-free-acc
 - More coming soon
 
 ### How To Install:
+Clone the repository into your project directory using:
+
+    git clone https://github.com/Jamonek/Robinhood
+
+Then navigate to the cloned directory, where `setup.py` is located. Now run the following to install:
+
     pip install .
     
 ### Converting to Python 3


### PR DESCRIPTION
The installation section in the README was missing a step. Specifically, the user first needs to clone the repo to their directory before running `pip install .`