### PR TITLE
Documented `dateutil` dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.13.0,<=2.18.4
 six>=1.10.0,<=1.11.0
+python-dateutil>=2.8.0


### PR DESCRIPTION
It's used in `Robinhood/Robinhood.py` but is not currently listed in `requirements.txt`.

I used the current version but earlier versions my work (I didn't test) so the version constraint might be too strict.