### PR TITLE
Added python-dateutil to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ __version__ = '1.0.1'
 REQUIRES = [
     'requests>=2.13.0,<=2.18.4',
     'six>=1.10.0,<=1.11.0',
+    'python-dateutil>=2.8.0'
 ]
 TEST = [
     'pytest~=3.0.0',


### PR DESCRIPTION
Since it was in requirements, we need this for `pip install .`, or else we have to manually install the additional component.